### PR TITLE
Update the alloy build command to work with 1.2 and up

### DIFF
--- a/tasks/lib/alloy.js
+++ b/tasks/lib/alloy.js
@@ -32,7 +32,7 @@ exports.init = function(grunt) {
             }
             // -q, --platform <platform> Target mobile platform [android,ios,mobileweb]
             if (undefined !== options.alloy.platform) {
-                args.push('-q', options.alloy.platform.join(','));
+                args.push('-c', 'platform=' + options.alloy.platform.join(','));
             }
         }
 


### PR DESCRIPTION
Using the -q option does not work with recent versions of Alloy, I updated alloy.js to use --config platform=ios so it can build. WFM with Alloy 1.2
